### PR TITLE
add default import

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,16 +8,22 @@ importers:
 
   .:
     dependencies:
+      ai:
+        specifier: ^5.0.92
+        version: 5.0.92(zod@4.1.12)
+      ai-sdk-tool-code-execution:
+        specifier: ^0.0.1
+        version: 0.0.1
       sandbox:
         specifier: ^1.0.3
         version: 1.0.3
+      zod:
+        specifier: ^4.1.12
+        version: 4.1.12
     devDependencies:
       '@types/node':
         specifier: ^24.10.1
         version: 24.10.1
-      ai:
-        specifier: ^5.0.92
-        version: 5.0.92(zod@4.1.12)
       dotenv:
         specifier: ^17.2.3
         version: 17.2.3
@@ -30,9 +36,6 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
-      zod:
-        specifier: ^4.1.12
-        version: 4.1.12
 
 packages:
 
@@ -427,6 +430,9 @@ packages:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  ai-sdk-tool-code-execution@0.0.1:
+    resolution: {integrity: sha512-YtJ9hnzSZ+KSb7AS/owOQhG1UPhScSo+j9MrSYtzSvaMs7i1f7aEWqe30zHKgDw8kRSDL5O5LEzhUjjDq9aiBQ==}
 
   ai@5.0.92:
     resolution: {integrity: sha512-EnPe3QXiD06Tg7iAt/oU3JSwedI1nuhEBnTjyfn1qTXaqmJ6qI4YG8wn/eBHRVXnmljDFDNYvGBC5pALYV1rAA==}
@@ -1126,6 +1132,16 @@ snapshots:
       - react-native-b4a
 
   acorn@8.15.0: {}
+
+  ai-sdk-tool-code-execution@0.0.1:
+    dependencies:
+      ai: 5.0.92(zod@4.1.12)
+      sandbox: 1.0.3
+      zod: 4.1.12
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+      - supports-color
 
   ai@5.0.92(zod@4.1.12):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,22 +8,16 @@ importers:
 
   .:
     dependencies:
-      ai:
-        specifier: ^5.0.92
-        version: 5.0.92(zod@4.1.12)
-      ai-sdk-tool-code-execution:
-        specifier: ^0.0.1
-        version: 0.0.1
       sandbox:
         specifier: ^1.0.3
         version: 1.0.3
-      zod:
-        specifier: ^4.1.12
-        version: 4.1.12
     devDependencies:
       '@types/node':
         specifier: ^24.10.1
         version: 24.10.1
+      ai:
+        specifier: ^5.0.92
+        version: 5.0.92(zod@4.1.12)
       dotenv:
         specifier: ^17.2.3
         version: 17.2.3
@@ -36,6 +30,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      zod:
+        specifier: ^4.1.12
+        version: 4.1.12
 
 packages:
 
@@ -430,9 +427,6 @@ packages:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-
-  ai-sdk-tool-code-execution@0.0.1:
-    resolution: {integrity: sha512-YtJ9hnzSZ+KSb7AS/owOQhG1UPhScSo+j9MrSYtzSvaMs7i1f7aEWqe30zHKgDw8kRSDL5O5LEzhUjjDq9aiBQ==}
 
   ai@5.0.92:
     resolution: {integrity: sha512-EnPe3QXiD06Tg7iAt/oU3JSwedI1nuhEBnTjyfn1qTXaqmJ6qI4YG8wn/eBHRVXnmljDFDNYvGBC5pALYV1rAA==}
@@ -1132,16 +1126,6 @@ snapshots:
       - react-native-b4a
 
   acorn@8.15.0: {}
-
-  ai-sdk-tool-code-execution@0.0.1:
-    dependencies:
-      ai: 5.0.92(zod@4.1.12)
-      sandbox: 1.0.3
-      zod: 4.1.12
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-      - supports-color
 
   ai@5.0.92(zod@4.1.12):
     dependencies:


### PR DESCRIPTION
`import { executeCode } from 'ai-sdk-tool-code-execution'` was giving me this error:

```
node:internal/modules/esm/resolve:314
  return new ERR_PACKAGE_PATH_NOT_EXPORTED(
         ^

Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in ..../node_modules/ai-sdk-tool-code-execution/package.json
    at exportsNotFound (node:internal/modules/esm/resolve:314:10)
    at packageExportsResolve (node:internal/modules/esm/resolve:604:13)
    at resolveExports (node:internal/modules/cjs/loader:657:36)
    at Function._findPath (node:internal/modules/cjs/loader:749:31)
    at node:internal/modules/cjs/loader:1387:27
    at nextResolveSimple (..../node_modules/.pnpm/tsx@4.20.5/node_modules/tsx/dist/register-D46fvsV_.cjs:4:1004)
    at ..../node_modules/.pnpm/tsx@4.20.5/node_modules/tsx/dist/register-D46fvsV_.cjs:3:2630
    at ..../node_modules/.pnpm/tsx@4.20.5/node_modules/tsx/dist/register-D46fvsV_.cjs:3:1542
    at resolveTsPaths (..../node_modules/.pnpm/tsx@4.20.5/node_modules/tsx/dist/register-D46fvsV_.cjs:4:760)
    at ..../node_modules/.pnpm/tsx@4.20.5/node_modules/tsx/dist/register-D46fvsV_.cjs:4:1102 {
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
}
```

I'm not totally sure of why the error happens but I did publish this fork to npm ([here](https://www.npmjs.com/package/@zsiegel1/ai-sdk-tool-code-execution)) and `pnpm add`'ed the fork with this change to confirm it fixes it for me. I'll unpublish that npm package when a fix is pushed to this repo that makes it work.

I think this issue only arises when executing with `tsx` (which I use for all Typescript scripting), this is from a chat with Claude:

> It's the package, not your Node version. The package is ESM-only ("type": "module") but its exports field only declares "import" — no "require" or "default" fallback. This is a common oversight by package authors.
> Best practice for npm packages is to include "default": "./dist/index.js" as a fallback for tools like tsx, Jest, and bundlers that resolve through CJS paths. Node 22 supports ESM fine, but tsx's loader needs that fallback
> [Me:] Will NextJS have this problem?
> No. Next.js uses webpack/turbopack for bundling, which reads the "import" condition directly and handles ESM-only packages fine. The issue was specific to tsx's CJS loader when running scripts directly. Your app will work.


Thank you!